### PR TITLE
Feat/text outlines

### DIFF
--- a/yashadvert/src/pages/AboutGTP/style.css
+++ b/yashadvert/src/pages/AboutGTP/style.css
@@ -41,6 +41,7 @@
     background-position-x: right;
     background-position-y: top;
     background-size: contain;
+    text-shadow:-1px -1px 0 #fefefe,1px -1px 0 #fefefe,-1px 1px 0 #fefefe,1px 1px 0 #fefefe;
 }
 
 .about_gtp_heading


### PR DESCRIPTION
A small change, that borrows a little accessibility trick, to make the text readable when it overlaps with the background image. Real simple stuff, and I've checked that it doesn't break things.  